### PR TITLE
Invalid operator fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-opencv=3.4.2
+opencv==3.4.2
 dlib==19.18.0
 numpy==1.17.3
 pillow>=6.2.2


### PR DESCRIPTION
In the requirements.txt file with the dependencies:

`opencv=3.4.2
dlib==19.18.0
numpy==1.17.3
pillow>=6.2.2`

OpenCV has one "=" instead of the needed "==" operator.